### PR TITLE
Enable support for use over HTTPS on Jinteki.net

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
   "content_scripts": [
     {
       "matches": [
-        "http://www.jinteki.net/*", "https://jinteki.zaroth.net/*"
+        "http://www.jinteki.net/*", "https://www.jinteki.net/*", "https://jinteki.zaroth.net/*"
       ],
       "js": ["lib/models/User.js", "lib/friends.js", "lib/options.js", "inline/lobby.js", "inline/injector.js", "inline/options.js"],
       "css": ["inline/jankteki.css"],

--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,7 @@
     "declarativeContent",
     "notifications",
     "storage",
-    "http://jinteki.net/*"
+    "http://jinteki.net/*",
+    "https://jinteki.net/*"
   ]
 }


### PR DESCRIPTION
Jinteki.net recently switched to using HTTPS by default, which means this extension no longer activates on Jinteki.net. This modifies the extension manifest to include https://www.jinteki.net/* in the list of sites where this extension gets activated.