### PR TITLE
New Feature. Option 'Widen Hq'

### DIFF
--- a/inline/gameboard.js
+++ b/inline/gameboard.js
@@ -4,12 +4,17 @@ var observer = new MutationObserver(function () {
     if (document.querySelector('#gameboard').style.display !== "none") {
 
         var hqNode = document.querySelector("[data-server='HQ']");
+        var gripNode = document.querySelector("[data-server='Grip']");
         var widenHqOption = document.body.classList.contains('widen-hq');
-        if(widenHqOption && hqNode) {
-          widenHqGlobal.start();
+        var side = getSide();
+
+        var nodeToWiden = side === 'runner' ? gripNode : hqNode;
+
+        if(widenHqOption && nodeToWiden) {
+          widenHqGlobal.start(nodeToWiden);
         }
 
-        if(widenHqOption && !hqNode) {
+        if(widenHqOption && !nodeToWiden) {
           widenHqGlobal.stop();
         }
 

--- a/inline/gameboard.js
+++ b/inline/gameboard.js
@@ -2,6 +2,17 @@ var socket = io.connect(iourl + '/lobby');
 
 var observer = new MutationObserver(function () {
     if (document.querySelector('#gameboard').style.display !== "none") {
+
+        var hqNode = document.querySelector("[data-server='HQ']");
+        var widenHqOption = document.body.classList.contains('widen-hq');
+        if(widenHqOption && hqNode) {
+          widenHqGlobal.start();
+        }
+
+        if(widenHqOption && !hqNode) {
+          widenHqGlobal.stop();
+        }
+
         createFixesPanel();
 
         var fixesPanel = document.querySelector('#fixes-pane .panel');

--- a/inline/injector.js
+++ b/inline/injector.js
@@ -1,6 +1,11 @@
 var s = document.createElement('script');
 s.src = chrome.extension.getURL('inline/gameboard.js');
+
+var widenScript = document.createElement('script');
+widenScript.src = chrome.extension.getURL('inline/widenHq.js');
+
 s.onload = function() {
     this.parentNode.removeChild(this);
 };
 (document.head || document.documentElement).appendChild(s);
+(document.head || document.documentElement).appendChild(widenScript);

--- a/inline/options.js
+++ b/inline/options.js
@@ -2,4 +2,8 @@ loadOptions().then(function (options) {
     if (options && options.horizontalScrolling) {
         document.body.classList.add('horizontal-scrolling');
     }
+
+    if (options && options.widenHq) {
+      document.body.classList.add('widen-hq');
+    }
 });

--- a/inline/widenHq.js
+++ b/inline/widenHq.js
@@ -1,0 +1,47 @@
+var widenHqGlobal;
+
+( function() {
+  var observer;
+
+  function resizeHq() {
+    var hq = $("[data-server='HQ']");
+    var cardWrappers = hq.find('.card-wrapper');
+    var numCards = cardWrappers.length;
+    var hqWidth = numCards * 60;
+    hqWidth = Math.min(hqWidth, 700);
+    hqWidth = Math.max(hqWidth, 383);
+    hq.width(hqWidth);
+    var step = hqWidth / numCards;
+    if (step > 60) {
+      step = 60;
+    }
+    var counterWidth = 0 - step;
+    var debugCounter = 0;
+    cardWrappers.each(function () {
+      counterWidth += step;
+      $(this).css({left: counterWidth});
+      debugCounter += 1;
+    });
+  }
+
+  function stop() {
+    observer.disconnect();
+  }
+
+  function start() {
+    var hqNode = document.querySelector("[data-server='HQ']");
+    observer = new MutationObserver(resizeHq);
+    var config = {attributes: true, childList: true, characterData: true, subtree: true};
+    observer.observe(hqNode, config);
+  }
+
+  widenHqGlobal = {
+    start: start,
+    stop: stop,
+  };
+
+})();
+
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = WidenHq;
+}

--- a/inline/widenHq.js
+++ b/inline/widenHq.js
@@ -1,26 +1,22 @@
 var widenHqGlobal;
 
 ( function() {
-  var observer;
-
-  function resizeHq() {
-    var hq = $("[data-server='HQ']");
-    var cardWrappers = hq.find('.card-wrapper');
+  function resizeHq(nodeToWiden) {
+    var $nodeToWiden = $(nodeToWiden);
+    var cardWrappers = $nodeToWiden.find('.card-wrapper');
     var numCards = cardWrappers.length;
-    var hqWidth = numCards * 60;
-    hqWidth = Math.min(hqWidth, 700);
-    hqWidth = Math.max(hqWidth, 383);
-    hq.width(hqWidth);
-    var step = hqWidth / numCards;
+    var nodeWidth = numCards * 60;
+    nodeWidth = Math.min(nodeWidth, 700);
+    nodeWidth = Math.max(nodeWidth, 383);
+    $nodeToWiden.width(nodeWidth);
+    var step = nodeWidth / numCards;
     if (step > 60) {
       step = 60;
     }
     var counterWidth = 0 - step;
-    var debugCounter = 0;
     cardWrappers.each(function () {
       counterWidth += step;
       $(this).css({left: counterWidth});
-      debugCounter += 1;
     });
   }
 
@@ -28,11 +24,11 @@ var widenHqGlobal;
     observer.disconnect();
   }
 
-  function start() {
-    var hqNode = document.querySelector("[data-server='HQ']");
-    observer = new MutationObserver(resizeHq);
+  function start(nodeToWiden) {
+    var bindedResize = resizeHq.bind(null, nodeToWiden);
+    observer = new MutationObserver(bindedResize);
     var config = {attributes: true, childList: true, characterData: true, subtree: true};
-    observer.observe(hqNode, config);
+    observer.observe(nodeToWiden, config);
   }
 
   widenHqGlobal = {

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
     }
   ],
   "options_page": "options/options.html",
-  "web_accessible_resources": ["inline/gameboard.js"],
+  "web_accessible_resources": ["inline/gameboard.js", "inline/widenHq.js"],
   "permissions": [
     "contextMenus",
     "declarativeContent",

--- a/options/options.html
+++ b/options/options.html
@@ -13,6 +13,10 @@
             <input type="checkbox" id="horizontal-scrolling">
             Enable horizontal scrolling <em>(experimental)</em>
         </label>
+        <label>
+            <input type="checkbox" id="widen-hq">
+            Enable widen hq <em>(experimental)</em>
+        </label>
         <input type="submit" value="Save Changes" class="button" id="save-options">
     </form>
 

--- a/options/options.js
+++ b/options/options.js
@@ -2,6 +2,10 @@ loadOptions().then(function (options) {
     if (options && options.horizontalScrolling) {
         document.getElementById('horizontal-scrolling')['checked'] = 'checked';
     }
+
+    if (options && options.widenHq) {
+        document.getElementById('widen-hq')['checked'] = 'checked';
+    }
 });
 
 document.getElementById('options').addEventListener('submit', function (e) {
@@ -9,6 +13,7 @@ document.getElementById('options').addEventListener('submit', function (e) {
 
     var options = {};
     options.horizontalScrolling = document.getElementById('horizontal-scrolling').checked;
+    options.widenHq = document.getElementById('widen-hq').checked;
 
     chrome.storage.sync.set({'options': options}, function () {
         var notificationOption = {


### PR DESCRIPTION
When user selects new option their HQ or Grip is dynamically sized to better display cards in their hand. Also works for spectators with the option enabled.

**Options**
<img width="397" alt="screen shot 2017-12-04 at 13 01 37" src="https://user-images.githubusercontent.com/32073440/33554101-4c8acf26-d8f3-11e7-8354-4d39014c1c41.png">

**HQ**
<img width="770" alt="screen shot 2017-12-04 at 12 53 20" src="https://user-images.githubusercontent.com/32073440/33554090-3aa70d4c-d8f3-11e7-9057-6e6dc6fd32f4.png">

**Grip**
<img width="799" alt="screen shot 2017-12-04 at 14 24 44 1" src="https://user-images.githubusercontent.com/32073440/33564179-c7a9c9fa-d911-11e7-9b90-f45ffaeabba4.png">
